### PR TITLE
Bugfix for all regions

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -5,10 +5,18 @@
   "manifest_version": 2,
   "content_scripts": [
     {
-      "matches": ["https://console.aws.amazon.com/*"],
-      "css": ["styles.css"],
-      "js": ["aws-pins.js"]
+      "matches": [
+        "https://console.aws.amazon.com/*"
+      ],
+      "css": [
+        "styles.css"
+      ],
+      "js": [
+        "aws-pins.js"
+      ]
     }
   ],
-  "icons": {"128": "logo.png" }
+  "icons": {
+    "128": "logo.png"
+  }
 }

--- a/manifest.json
+++ b/manifest.json
@@ -6,7 +6,10 @@
   "content_scripts": [
     {
       "matches": [
-        "https://console.aws.amazon.com/*"
+        "https://*.console.aws.amazon.com/*",
+        "https://phd.aws.amazon.com/*",
+        "https://*.console.amazonaws-us-gov.com/*",
+        "https://*.console.amazonaws.cn/*"
       ],
       "css": [
         "styles.css"


### PR DESCRIPTION
Hey,

currently the plugin only works in `us-east-1` because all other regions have a URL prefix so the URL matcher in the manifest wont work there. Just adding a simple `*` will make this great plugin work in all regions :)