### PR TITLE
Wait until the favorites-container exists

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,5 @@ Find it [here](https://chrome.google.com/webstore/detail/aws-favorites-to-pins/n
 - Fetches first 7 of these favorites, clones them into new divs and adds on to the nav header element
 
 # Limitations
-- Sometimes, fetching the `favorites-container` does not work (e.g., when page is refreshed sometimes/services that take time to load; Try going to CodePipeline and then to CodeDeploy) and hence pins don't show up (not sure why)
 - Favorites menu is alphabetically ordered and only the top 7 of them are picked to be pins. Can't pick and choose to our liking
 - Service name label and icon are both shown always. Not configurable to show just the icon/label
-

--- a/aws-pins.js
+++ b/aws-pins.js
@@ -1,9 +1,16 @@
 
 // ------- Main Driver Begins ---------
 
-const pins = createPinsFromFavs();
-addPinsToHeader(pins);
-
+/*
+* Check regularly until the required div appears on the page
+*/
+var checkExist = setInterval(function () {
+    if (document.querySelector('div[data-testid="favorites-container"]')) {
+        const pins = createPinsFromFavs();
+        addPinsToHeader(pins);
+        clearInterval(checkExist);
+    }
+}, 100);
 // ------- Main Driver Ends -----------
 
 /*


### PR DESCRIPTION
It's me again :D

The problem why the plugin sometimes wont work is because the plugin runs faster than the page can load and then the element doesn't exists yet and the `document.getElement` will fail because it can't find an element to match.

My solution is probably not the most beautiful code (using a MutationObserver would probably be the better way), but for now this code works and the plugin loads always.